### PR TITLE
Test: use separate databases for MetaStore tests

### DIFF
--- a/plugin-metastore-mongo/src/test/kotlin/IdentityStoreTest.kt
+++ b/plugin-metastore-mongo/src/test/kotlin/IdentityStoreTest.kt
@@ -40,7 +40,7 @@ class IdentityStoreTest {
             val config = OblxConfig()
             mongoClient = MongoClient.create(
                 vertx,
-                JsonObject().put("connection_string", config.mongoConnectionUri).put("db_name", config.mongoDbName)
+                JsonObject().put("connection_string", config.mongoConnectionUri).put("db_name", config.mongoDbName + "-testIdentityStore")
             )
             identityStore = MongoDBMetaStore(mongoClient)
 

--- a/plugin-metastore-mongo/src/test/kotlin/TestMetaStore.kt
+++ b/plugin-metastore-mongo/src/test/kotlin/TestMetaStore.kt
@@ -31,7 +31,7 @@ class TestMetaStore {
             mongoClient = MongoClient.create(
                 vertx,
                 JsonObject().put("connection_string", config.mongoConnectionUri)
-                    .put("db_name", config.mongoDbName + "-test")
+                    .put("db_name", config.mongoDbName + "-testMetaStore")
             )
             metaStore = MongoDBMetaStore(mongoClient)
 

--- a/plugin-metastore-mongo/src/test/kotlin/TestSorting.kt
+++ b/plugin-metastore-mongo/src/test/kotlin/TestSorting.kt
@@ -28,7 +28,7 @@ class TestSorting {
         val mongoClient = MongoClient.create(
             vertx,
             JsonObject().put("connection_string", config.mongoConnectionUri)
-                .put("db_name", config.mongoDbName + "-test")
+                .put("db_name", config.mongoDbName + "-testSorting")
         )
         val metaStore = MongoDBMetaStore(mongoClient)
 

--- a/plugin-metastore-mongo/src/test/kotlin/TestUsageLimits.kt
+++ b/plugin-metastore-mongo/src/test/kotlin/TestUsageLimits.kt
@@ -36,7 +36,7 @@ class TestUsageLimits {
             mongoClient = MongoClient.create(
                 vertx,
                 JsonObject().put("connection_string", config.mongoConnectionUri)
-                    .put("db_name", "${config.mongoDbName}-test")
+                    .put("db_name", config.mongoDbName + "-testUsageLimits")
             )
             identityStore = MongoDBMetaStore(mongoClient)
 

--- a/plugin-metastore-mongo/src/test/kotlin/UniquenessTest.kt
+++ b/plugin-metastore-mongo/src/test/kotlin/UniquenessTest.kt
@@ -42,7 +42,7 @@ class UniquenessTest {
             mongoClient = MongoClient.create(
                 vertx,
                 JsonObject().put("connection_string", config.mongoConnectionUri)
-                    .put("db_name", "${config.mongoDbName}-test")
+                    .put("db_name", config.mongoDbName + "-testUniqueness")
             )
             identityStore = MongoDBMetaStore(mongoClient)
             initialize(identityStore as MongoDBMetaStore, mongoClient, config)

--- a/plugin-metastore-mongo/src/test/kotlin/UpdateTest.kt
+++ b/plugin-metastore-mongo/src/test/kotlin/UpdateTest.kt
@@ -38,7 +38,7 @@ class UpdateTest {
             mongoClient = MongoClient.create(
                 vertx,
                 JsonObject().put("connection_string", config.mongoConnectionUri)
-                    .put("db_name", "${config.mongoDbName}-test")
+                    .put("db_name", config.mongoDbName + "-testUpdate")
             )
             metaStore = MongoDBMetaStore(mongoClient)
 


### PR DESCRIPTION
This PR attempts to fix the indeterministic issue with the MetaStore tests failing due to locked collections.

All MetaStore tests now use their own distinct databases so there can't be any interference between them.
Closing #14 and #47