### PR TITLE
Fix: calculate outgoing events with instead of average response size

### DIFF
--- a/plugin-monitoring-prometheus/src/main/kotlin/idlab/obelisk/plugins/monitoring/prometheus/impl/PrometheusMonitoringDataProvider.kt
+++ b/plugin-monitoring-prometheus/src/main/kotlin/idlab/obelisk/plugins/monitoring/prometheus/impl/PrometheusMonitoringDataProvider.kt
@@ -74,13 +74,9 @@ class PrometheusMonitoringDataProvider(vertx: Vertx, config: OblxConfig) : Monit
         restrictTo: ConsumptionType?
     ): Single<List<MonitoringTimeSeries>> {
         val consumedViaQueryQ = if (datasetId != null) {
-            "rate(oblx_query_response_size_sum${filter(datasetId)}[$duration])/rate(oblx_query_response_size_count${
-                filter(
-                    datasetId
-                )
-            }[$duration])"
+            "rate(oblx_query_response_size_sum${filter(datasetId)}[$duration])"
         } else {
-            "rate(oblx_query_global_response_size_sum[$duration])/rate(oblx_query_global_response_size_count[$duration])"
+            "rate(oblx_query_global_response_size_sum[$duration])"
         }
 
         val consumedViaSSEQ = "rate(oblx_sse_events_streamed_total${filter(datasetId)}[$duration])"


### PR DESCRIPTION
Catalog was showing quite high outgoing events and scaling event of the query pod instances showed an increase in outgoing events linear with the increase in amount of instances.

The `countConsumedEvents`  method has been fixed and now uses a rate of the _sum instead of calculating the average.
Other PromQL queries were also checked and seem fine.