### PR TITLE
feat: remove docs v2 link

### DIFF
--- a/web-catalog/src/app/modules/home/pages/home/home.component.html
+++ b/web-catalog/src/app/modules/home/pages/home/home.component.html
@@ -79,14 +79,6 @@
               </docs-link>
             </div>
           </div>
-          <div class="row pt-3">
-            <div class="col">
-              <docs-link class="shadow-sm" [caption]="docs.v2.caption" [help]="docs.v2.help" [path]="docs.v2.path"
-                theme="secondary">
-              </docs-link>
-            </div>
-          </div>
-
         </div>
         <div class="col-6 ">
           <div class="featured">

--- a/web-catalog/src/app/modules/home/pages/home/home.component.ts
+++ b/web-catalog/src/app/modules/home/pages/home/home.component.ts
@@ -1,25 +1,37 @@
-import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { Router } from '@angular/router';
-import { AuthService, ConfigService, HeaderService, ObeliskService } from '@core/services';
-import { Customization, CustomizationService } from '@core/services/customization.service';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { ObeliskDataSource } from '@shared/datasources';
-import { InfoAnnouncementComponent } from '@shared/modals';
-import { Announcement, GlobalMetaStats, ServiceStatus } from '@shared/model/types';
-import { AgoPipe } from '@shared/pipes';
-import { Colors, Utils } from '@shared/utils';
-import { forkJoin, of, timer, zip } from 'rxjs';
-import { catchError, switchMapTo, tap } from 'rxjs/operators';
+import { AfterViewInit, Component, OnDestroy, OnInit } from "@angular/core";
+import { DomSanitizer } from "@angular/platform-browser";
+import { Router } from "@angular/router";
+import {
+  AuthService,
+  ConfigService,
+  HeaderService,
+  ObeliskService,
+} from "@core/services";
+import {
+  Customization,
+  CustomizationService,
+} from "@core/services/customization.service";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { ObeliskDataSource } from "@shared/datasources";
+import { InfoAnnouncementComponent } from "@shared/modals";
+import {
+  Announcement,
+  GlobalMetaStats,
+  ServiceStatus,
+} from "@shared/model/types";
+import { AgoPipe } from "@shared/pipes";
+import { Colors, Utils } from "@shared/utils";
+import { forkJoin, of, timer, zip } from "rxjs";
+import { catchError, switchMapTo, tap } from "rxjs/operators";
 
 const REFRESH_MS = 60 * 1000;
 
 @UntilDestroy()
 @Component({
-  selector: 'app-home',
-  templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  selector: "app-home",
+  templateUrl: "./home.component.html",
+  styleUrls: ["./home.component.scss"],
 })
 export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   title: string;
@@ -27,20 +39,15 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   newsDatasource: ObeliskDataSource<Announcement>;
   docs = {
     auth: {
-      caption: 'Authentication',
-      path: '/docs/guides/auth.html',
-      help: 'Learn how to authenticate your Client application or your Client’s users with Obelisk'
+      caption: "Authentication",
+      path: "/docs/guides/auth.html",
+      help: "Learn how to authenticate your Client application or your Client’s users with Obelisk",
     },
     filters: {
-      caption: 'Filters',
-      path: '/docs/tech_reference/filters.html',
-      help: 'Learn how to make ue of filter expressions when querying data and metata'
+      caption: "Filters",
+      path: "/docs/tech_reference/filters.html",
+      help: "Learn how to make ue of filter expressions when querying data and metata",
     },
-    v2: {
-      caption: 'Obelisk v2 Docs',
-      path: '/api/v2/docs',
-      help: 'Find the old Obelisk v2 docs here'
-    }
   };
   status: ServiceStatus;
   datasets: any[] = [];
@@ -62,49 +69,58 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   ) {
     this.cz = czs.load();
     this.header.setTitle(this.cz.brandName);
-    this.newsDatasource = new ObeliskDataSource(this.obelisk.listAnnouncements.bind(this.obelisk));
+    this.newsDatasource = new ObeliskDataSource(
+      this.obelisk.listAnnouncements.bind(this.obelisk)
+    );
   }
 
   ngOnInit() {
-    this.header.setSidebarState('none');
+    this.header.setSidebarState("none");
     this.title = this.cz.brandName;
     // this.obelisk.getGlobalMetaStats().subscribe(stats => this.stats = stats);
-    this.obelisk.listPublishedDatasets({ limit: 40 }).subscribe(page => {
+    this.obelisk.listPublishedDatasets({ limit: 40 }).subscribe((page) => {
       const total = page.items.length;
       const selected = [];
       while (selected.length < 3 && selected.length != page.items.length) {
         const ds = page.items[Math.floor(Math.random() * total)];
-        if (selected.every(d => d.id != ds.id)) {
+        if (selected.every((d) => d.id != ds.id)) {
           selected.push(ds);
         }
       }
       this.datasets = selected;
     });
     let i = 0;
-    timer(0, REFRESH_MS).pipe(
-      untilDestroyed(this),
-      switchMapTo(forkJoin({
-        stats: this.obelisk.getGlobalMetaStats().pipe(tap(stats => this.stats = stats), catchError(err => of(err))),
-        status: this.obelisk.getStatusGlobal().pipe(tap(status => {
-          this.status = status;
-          this.lastUpdate = Date.now();
-        }), catchError(err => of(err)))
-      }))
-    )
-      .subscribe(({ stats, status }) => { });
+    timer(0, REFRESH_MS)
+      .pipe(
+        untilDestroyed(this),
+        switchMapTo(
+          forkJoin({
+            stats: this.obelisk.getGlobalMetaStats().pipe(
+              tap((stats) => (this.stats = stats)),
+              catchError((err) => of(err))
+            ),
+            status: this.obelisk.getStatusGlobal().pipe(
+              tap((status) => {
+                this.status = status;
+                this.lastUpdate = Date.now();
+              }),
+              catchError((err) => of(err))
+            ),
+          })
+        )
+      )
+      .subscribe(({ stats, status }) => {});
   }
 
   ngOnDestroy() {
     this.newsDatasource.cleanUp();
   }
 
-  ngAfterViewInit() {
-
-  }
+  ngAfterViewInit() {}
 
   goToDataset(dataset: any) {
-    this.router.navigate(['ds', dataset.id], {
-      state: dataset
+    this.router.navigate(["ds", dataset.id], {
+      state: dataset,
     });
   }
 
@@ -113,38 +129,61 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   getBackgroundImgUrl(ds: any) {
-    return this.san.bypassSecurityTrustStyle('url(./assets/img/project/' + ds.name + '.jpg), url(./assets/img/project/_fallback.png)');
+    return this.san.bypassSecurityTrustStyle(
+      "url(./assets/img/project/" +
+        ds.name +
+        ".jpg), url(./assets/img/project/_fallback.png)"
+    );
   }
 
   get ingestRate() {
-    return this.stats?.ingestedEventsRate ? this.stats?.ingestedEventsRate.map(record => record.value) : [];
+    return this.stats?.ingestedEventsRate
+      ? this.stats?.ingestedEventsRate.map((record) => record.value)
+      : [];
   }
 
   get ingestTime() {
-    return this.stats?.ingestedEventsRate ? this.stats?.ingestedEventsRate[this.stats.ingestedEventsRate.length - 1]?.timestamp : null;
+    return this.stats?.ingestedEventsRate
+      ? this.stats?.ingestedEventsRate[this.stats.ingestedEventsRate.length - 1]
+          ?.timestamp
+      : null;
   }
 
   get queryRate() {
-    return this.stats?.consumedEventsRate ? this.stats?.consumedEventsRate.map(record => record.value) : [];
+    return this.stats?.consumedEventsRate
+      ? this.stats?.consumedEventsRate.map((record) => record.value)
+      : [];
   }
 
   get queryTime() {
-    return this.stats?.consumedEventsRate ? this.stats?.consumedEventsRate[this.stats?.consumedEventsRate.length - 1]?.timestamp : null;
+    return this.stats?.consumedEventsRate
+      ? this.stats?.consumedEventsRate[
+          this.stats?.consumedEventsRate.length - 1
+        ]?.timestamp
+      : null;
   }
 
   goToApiConsole() {
     const host = this.config.getCfg().clientHost;
-    const apiConsoleUri = host + '/apiconsole'
-    const isRunningLocal = host.startsWith('http://localhost') || host.startsWith('http://127.0.0.1');
-    window.open(isRunningLocal ? 'http://localhost:4200' : apiConsoleUri, '_blank');
+    const apiConsoleUri = host + "/apiconsole";
+    const isRunningLocal =
+      host.startsWith("http://localhost") ||
+      host.startsWith("http://127.0.0.1");
+    window.open(
+      isRunningLocal ? "http://localhost:4200" : apiConsoleUri,
+      "_blank"
+    );
   }
 
   goToApiReference() {
-    window.open('https://obelisk.docs.apiary.io/', '_blank');
+    window.open("https://obelisk.docs.apiary.io/", "_blank");
   }
 
   openAnnouncement(announcement: Announcement) {
-    const ref = this.modal.open(InfoAnnouncementComponent, { size: 'lg', scrollable: true });
+    const ref = this.modal.open(InfoAnnouncementComponent, {
+      size: "lg",
+      scrollable: true,
+    });
     ref.componentInstance.initFromAnnouncement(announcement);
   }
 
@@ -152,11 +191,13 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.status?.history == null) {
       return [];
     } else {
-      return this.status.history
+      return this.status.history;
     }
   }
 
   get statusTooltipMsg() {
-    return `Status history of last 30 mins.<br><small>Updated ${this.agoPipe.transform(this.lastUpdate)}</small>`
+    return `Status history of last 30 mins.<br><small>Updated ${this.agoPipe.transform(
+      this.lastUpdate
+    )}</small>`;
   }
 }


### PR DESCRIPTION
This update removes the _Obelisk v2 Docs_ link from the main page (see image below). These docs are no longer relevant and it seems a lot of people are clicking this link instead of the _Documentation_ link on the top right op the page.

![image](https://github.com/idlab-discover/obelisk/assets/1684858/e40f9537-6824-4a15-8785-e6993053f5de)

Auto formatting tools changed some stuff, but basically I removed the `<div>` element from the html page and the `v2` key and value object from the `docs` object in the ts file.